### PR TITLE
Fix self reference in ChkData unitary helpers

### DIFF
--- a/aiida_supercon/data/chk.py
+++ b/aiida_supercon/data/chk.py
@@ -164,12 +164,13 @@ class ChkData(SinglefileData):
         return self.base.attributes.get('n_dis')
     
     def get_Udis(self):
-        
+        """Return the disentanglement matrices sorted by band flag."""
+
         n_kpts = self.n_kpts
         n_wann = self.n_wann
 
         # 类型 T = np.complex128（由 Uml[0] 推断）
-        dtype = chk.Uml[0].dtype
+        dtype = self.Uml[0].dtype
 
         if not self.have_disentangled:
             # 每个 k 点下单位矩阵（形状 n_wann x n_wann）
@@ -183,13 +184,14 @@ class ChkData(SinglefileData):
 
         return Udis_sorted
 
-    def get_U(chk):
-        if not chk.have_disentangled:
-            # Return deepcopy for safety, so that chk.Uml is not modified
+    def get_U(self):
+        """Return the overall unitary transformation matrices."""
+        if not self.have_disentangled:
+            # Return deepcopy for safety, so that self.Uml is not modified
             return self.Uml.copy()
 
         Udis = self.get_Udis()  # 这是一个 list of np.ndarray，长度为 n_kpts
-        Uml = self.Uml # list of np.ndarray
+        Uml = self.Uml  # list of np.ndarray
 
         U = [d @ m for d, m in zip(Udis, Uml)]
         return U

--- a/tests/data/test_chk.py
+++ b/tests/data/test_chk.py
@@ -1,0 +1,17 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+chk_module = pytest.importorskip('aiida_supercon.data.chk')
+ChkData = chk_module.ChkData
+
+
+def test_get_u_without_disentangled():
+    class Dummy:
+        have_disentangled = False
+        Uml = [np.eye(2, dtype=np.complex128)]
+        n_kpts = 1
+        n_wann = 2
+
+    U = ChkData.get_U(Dummy())
+    assert len(U) == 1
+    assert np.array_equal(U[0], np.eye(2))


### PR DESCRIPTION
## Summary
- fix incorrect self usage in `ChkData.get_U` and `ChkData.get_Udis`
